### PR TITLE
chore: bump pnpm from 8.14.1 to 9.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
 		"vite": "^5.4.11"
 	},
 	"type": "module",
-	"packageManager": "pnpm@8.14.1"
+	"packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
lockfile v9 が使われているが、これは pnpm v9 で採用されたものであり `packpage.json` で指定されている `pnpm@8.14.1` では対応していない。

このPRでは `package.json` 内の `packageManager` を更新する。

- see [Release pnpm v9.0.0](https://github.com/pnpm/pnpm/releases/tag/v9.0.0#:~:text=Lockfile%20v9%20is%20adopted.)