### PR TITLE
chore: dependabotを構築

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+ 
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"


### PR DESCRIPTION
依存関係を更新してくれるdependabotを構築しました

構築内容: 
- pnpm-lock.yamlとpackage.jsonを週1で確認してアップデートがあればPRを自動で作成する
- PRはタイトル先頭に「deps: 」が付けるように
- PRにはdependenciesのlabelを付けるように
- [semver](https://semver.org/)におけるpatch, minor updateについては幾つかの更新を1つのPRにまとめるように