### PR TITLE
chore: dependabotの稼働間隔を月一に

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: 'deps'
     labels:


### PR DESCRIPTION
security的な指摘はメールでくるので、dependabotの稼働はそこまで多くなくてよくないか？となった